### PR TITLE
Update ember

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - npm install -g bower
   - bower --version
   - npm install phantomjs-prebuilt
-  - phantomjs --version
+  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
   - npm install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # telling-stories-dashboard
 [![Build Status](https://travis-ci.org/mvdwg/telling-stories-dashboard.svg?branch=master)](https://travis-ci.org/mvdwg/telling-stories-dashboard)
+![Ember versions](https://embadge.io/v1/badge.svg?start=2.8.0)
 
 Dashboard for [telling-stories](https://github.com/mvdwg/telling-stories#readme).
 

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,7 @@
 {
   "name": "telling-stories-dashboard",
   "dependencies": {
-    "ember": "~2.7.0",
-    "ember-cli-shims": "0.1.1",
-    "ember-qunit-notifications": "0.1.0"
+    "ember": "~2.8.0",
+    "ember-cli-shims": "0.1.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var EngineAddon = require('ember-engines/lib/engine-addon');
 
 module.exports = EngineAddon.extend({
   name: 'telling-stories-dashboard',
+  lazyLoading: false,
 
   included: function(app) {
     // see: https://github.com/ember-cli/ember-cli/issues/3718

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
-    "ember-cli": "2.7.0",
+    "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.0.0",
+    "ember-cli-qunit": "^2.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
@@ -48,7 +48,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.1.0",
-    "ember-engines": "^0.2.11"
+    "ember-engines": "^0.3.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import Resolver from 'ember-engines/resolver';
+import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 

--- a/tests/dummy/app/resolver.js
+++ b/tests/dummy/app/resolver.js
@@ -1,3 +1,3 @@
-import Resolver from 'ember-resolver';
+import Resolver from 'ember-engines/resolver';
 
 export default Resolver;


### PR DESCRIPTION
ember 2.8.0 needs a different version of ember-engines. This PR updates to the latest one. We lose  compatibility with previous versions of ember 😞 